### PR TITLE
chore: Need tslib to compile the module

### DIFF
--- a/guide/cli.md
+++ b/guide/cli.md
@@ -109,10 +109,10 @@ Koishi 支持直接调用 TypeScript 编写的插件。首先安装 typescript �
 
 <panel-view class="code" type="package-manager">
 ```npm
-npm i typescript ts-node -D
+npm i typescript ts-node tslib -D
 ```
 ```yarn
-yarn add typescript ts-node -D
+yarn add typescript ts-node tslib -D
 ```
 </panel-view>
 


### PR DESCRIPTION
When using ts, you need tslib to compile the module.

such as: ts-node ./src/index.ts